### PR TITLE
:seedling: Use pre-built image for action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Verifier action
       id: verifier
-      uses: ./
+      uses: ./action-nightly
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/action-nightly/action.yml
+++ b/action-nightly/action.yml
@@ -6,7 +6,4 @@ inputs:
     required: true
 runs:
   using: docker
-  # this is built using GCB by building the Dockerfile in this directory on
-  # every tagged release.  After tagging a release, a new version should
-  # automatically appear.
-  image: 'docker://gcr.io/kubebuilder/pr-verifier:v0.1.1'
+  image: '../Dockerfile'


### PR DESCRIPTION
This will use a prebuilt image that's automatically built for this
repository for each tag by GCB.  This should speed up action execution a
bit.

The version in this repo will still run from the local code though, so
we can still fix bugs.  That configuration lives in the `action-nightly`
subdirectory, and can also be referenced by external projects.