### PR TITLE
:book: Add sample workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   verify:

--- a/README.md
+++ b/README.md
@@ -21,30 +21,8 @@ $ go run sigs.k8s.io/kubebuilder-release-tools/notes -r beta
 This repository acts as a GitHub action for verifying PR titles match the
 [release notes generation requirements](/VERSIONING.md), as well as some
 basic descriptiveness checks.  You can use it in your repository by adding
-a workflow (e.g. `.github/workflows/verifier.yml`) as such:
-
-```yaml
-name: PR Verifier
-
-on:
-  # NB: using `pull_request_target` runs this in the context of
-  # the base repository, so it has permission to upload to the checks API.
-  # This means changes won't kick in to this file until merged onto the
-  # main branch.
-  pull_request_target:
-    types: [opened, edited, reopened]
-
-jobs:
-  verify:
-    runs-on: ubuntu-latest
-    name: verify PR contents
-    steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-```
+a workflow (e.g. `.github/workflows/verifier.yml`), such as
+[sample-workflows/verifier.yml](sample-workflows/verifier.yml).
 
 The code that actually runs lives in [verify/cmd](/verify/cmd), while
 [/verify](/verify) contains a framework for running PR description checks
@@ -69,6 +47,12 @@ $ git pull --tags upstream
 $ git tag -f vX vX.Y.Z
 $ git push upstream refs/tags/vX
 ```
+
+## Common GitHub Action Workflows
+
+The [sample-workflows](/sample-workflows) directory includes workflows to
+be used across all KubeBuilder projects, such as the PR verifier, Go
+lints, etc.
 
 ## KubeBuilder Project Versioning
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -120,12 +120,12 @@ repository][rel-tools]:
   unless the tool mentions needing manual edits.
 
 * the [GitHub actions][action] in this repo will verify PRs using the
-  verifier code from [verify][/verify].  If you want to add new checks,
+  verifier code from [verify](/verify).  If you want to add new checks,
   you can do it there.
 
 [rel-tools]: https://sigs.k8s.io/kubebuilder-release-tools
 
-[actions-wf]: /action.yml
+[action]: /action.yml
 
 ## PR Process
 

--- a/sample-workflows/.golangci.yml
+++ b/sample-workflows/.golangci.yml
@@ -1,0 +1,51 @@
+run:
+  deadline: 5m
+linters-settings:
+  dupl:
+    threshold: 400
+issues:
+  # don't skip warning about doc comments
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - linters: [gosec]
+      path: "test/e2e/*"
+  # turn this on to ignore return value checks on
+  # * fmt.Fprintf to stdout/error
+  # * Close/Flush/Remove/RemoveAll
+  # * Setenv/UnSetenv
+  #- linters: [errcheck]
+  #  text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked"
+linters:
+  disable-all: true
+  enable:
+  # keep these sorted if you modify (e.g. in vim, linewise visual + :sort)
+  - deadcode
+  - dupl
+  - errcheck
+  - exportloopref
+  - gocyclo
+  - gofmt
+  - goimports
+  - golint
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - maligned
+  - misspell
+  - nakedret
+  - prealloc
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - varcheck
+
+  # These may be useful, but are generally more annoying than not:
+  # - goconst  # this one doesn't quite know what is and isn't a magic string
+  # - interfacer # doesn't understand that interfaces have semantic meaning
+  # - lll # fiddly, use your best judgement

--- a/sample-workflows/README.md
+++ b/sample-workflows/README.md
@@ -1,0 +1,28 @@
+# Sample GitHub Actions Workflows
+
+These include GitHub Actions Worflows for use in KubeBuilder projects.
+
+## PR Verifier
+
+**File(s)**:
+
+- [verifier.yml](verifier.yml) (`/.github/workflows/verifier.yml`)
+
+This uses the [PR Verifier Action](/action.yml) to verify PR title and
+contents according to [the PR guidelines](/VERSIONING.md).
+
+[verifier-action]: /action.yml
+
+## Lint
+
+**File(s)**:
+
+- [lint.yml](lint.yml) (`/.github/workflows/lint.yml`)
+- [.golangci.yml](.golangci.yml) (`/.golangci.yml`)
+
+This uses [golangci-lint](https://github.com/golangci/golangci-lint) to
+lint our code.
+
+Use the included config file at the root of your repo to configure what
+linters run by default (golangci-lint has some strange defaults, and this
+config should be used more-or-less for all KubeBuilder projects).

--- a/sample-workflows/lint.yml
+++ b/sample-workflows/lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+
+on:
+  # run on PRs...
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+  # ... and also continuously
+  push:
+    branches:
+      - master
+
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be
+          # specified without patch version: we always use the latest patch
+          # version.
+          version: v1.29

--- a/sample-workflows/verifier.yml
+++ b/sample-workflows/verifier.yml
@@ -1,0 +1,22 @@
+name: PR Verifier
+
+on:
+  # NB: using `pull_request_target` runs this in the context of
+  # the base repository, so it has permission to upload to the checks API.
+  # This means changes won't kick in to this file until merged onto the
+  # main branch.
+  pull_request_target:
+    # synchronize because this will cause the HEAD commit to change,
+    # invalidating where we've placed our results
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: verify PR contents
+    steps:
+    - name: Verifier action
+      id: verifier
+      uses: kubernetes-sigs/kubebuilder-release-tools@v0.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds sample actions workflows for the verifier (moved from README)
and golangci-lint, adapted from the ones in KB and CR, plus
instructions.