### PR TITLE
📖 Assign a name to the PR verifier workflow of this repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+name: PR Verifier
+
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]


### PR DESCRIPTION
# Description
Currently, the workflow used in this repo, which uses the GitHub action developed in this repo, has no name. Therefore, `.github/workflows/main.yaml` is being used, as it can be seen in the checks for this PR.

# Motivation
UX