### PR TITLE
📖 Update RELEASE.md to specify googlegroup and project name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,4 +6,4 @@ The Kubernetes Template Project is released on an as-needed basis. The process i
 1. All [OWNERS](OWNERS) must LGTM this release
 1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
 1. The release issue is closed
-1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+1. An announcement email is sent to `kubebuilder@googlegroups.com` with the subject `[ANNOUNCE] kubebulder-release-tools $VERSION is released`


### PR DESCRIPTION
# Description
Update the `RELEASE.md` file to:
- Update google group to the kubebuilder one as notifying kubernetes-dev about a new release of a release-tool for kubebuilder sounds like an overkill and even can be considered spam.
- Update the project name

# Motivation
Clarify release process.