### PR TITLE
🌱 Include action execution for PR code

### DIFF
--- a/.github/actions/verifier/action.yml
+++ b/.github/actions/verifier/action.yml
@@ -6,4 +6,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: '../Dockerfile'
+  image: '../../../Dockerfile'

--- a/.github/actions/verifier/action.yml
+++ b/.github/actions/verifier/action.yml
@@ -4,6 +4,10 @@ inputs:
   github_token:
     description: "the github_token provided by the actions runner"
     required: true
+  suffix:
+    description: "suffix for Check Run names"
+    required: false
+    default: ""
 runs:
   using: docker
   image: '../../../Dockerfile'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   verify:
-    name: Verify PR contents
+    name: Verify PR contents (${{ github.repository }}:${{ github.base_ref }})
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,3 +15,18 @@ jobs:
         uses: ./.github/actions/verifier
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  verify-pr:
+    name: Verify PR contents (${{ github.event.pull_request.head.repo.full_name }}:${{ github.head_ref }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+      - name: Verifier action
+        uses: ./.github/actions/verifier
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          suffix: (${{ github.event.pull_request.head.repo.full_name }}:${{ github.head_ref }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,17 @@
+name: PR Verifier
+
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
   verify:
+    name: Verify PR contents
     runs-on: ubuntu-latest
-    name: verify PR contents
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Verifier action
-      id: verifier
-      uses: ./action-nightly
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verifier action
+        uses: ./.github/actions/verifier
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The code that actually runs lives in [verify/cmd](/verify/cmd), while
 from GitHub actions & uploading the result via the GitHub checks API.
 
 This repo itself uses a "live" version of the action that always rebuilds
-from the local code, which lives in [action-nightly](/action-nightly).
+from the local code (master branch), which lives in 
+[.github/actions/verifier](/.github/actions/verifier).
 
 ### Updating the action
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The code that actually runs lives in [verify/cmd](/verify/cmd), while
 [/verify](/verify) contains a framework for running PR description checks
 from GitHub actions & uploading the result via the GitHub checks API.
 
-This repo itself uses a "live" version of the action that always rebuilds
-from the local code (master branch), which lives in 
+This repo itself uses two "live" version of the action that always rebuilds
+from the local code (master branch) and from the PR branch, which lives in 
 [.github/actions/verifier](/.github/actions/verifier).
 
 ### Updating the action

--- a/verify/common.go
+++ b/verify/common.go
@@ -35,6 +35,7 @@ type ActionsEnv struct {
 	Repo   string
 	Event  *github.PullRequestEvent
 	Client *github.Client
+	Suffix string
 }
 
 func setupEnv() (*ActionsEnv, error) {
@@ -79,6 +80,7 @@ func setupEnv() (*ActionsEnv, error) {
 		Repo:   ownerAndRepo[1],
 		Event:  &event,
 		Client: client,
+		Suffix: os.Getenv("INPUT_SUFFIX"),
 	}, nil
 }
 
@@ -104,6 +106,10 @@ func RunPlugins(plugins ...PRPlugin) ActionsCallback {
 		var done sync.WaitGroup
 
 		for _, plugin := range plugins {
+			if env.Suffix != "" {
+				plugin.Name += " " + env.Suffix
+			}
+
 			done.Add(1)
 			go func(plugin PRPlugin) {
 				defer done.Done()

--- a/verify/logger.go
+++ b/verify/logger.go
@@ -18,18 +18,31 @@ package verify
 
 import (
 	"fmt"
+	"strings"
+)
+
+const (
+	errorPrefix   = "::error::"
+	debugPrefix   = "::debug::"
+	warningPrefix = "::debug::"
 )
 
 type logger struct{}
 
-func (logger) errorf(format string, args ...interface{}) {
-	fmt.Printf("::error::"+format+"\n", args...)
+func (logger) log(prefix, content string) {
+	for _, s := range strings.Split(content, "\n") {
+		fmt.Println(prefix + s)
+	}
 }
 
-func (logger) debugf(format string, args ...interface{}) {
-	fmt.Printf("::debug::"+format+"\n", args...)
+func (l logger) errorf(format string, args ...interface{}) {
+	l.log(errorPrefix, fmt.Sprintf(format, args...))
 }
 
-func (logger) warningf(format string, args ...interface{}) {
-	fmt.Printf("::warning::"+format+"\n", args...)
+func (l logger) debugf(format string, args ...interface{}) {
+	l.log(debugPrefix, fmt.Sprintf(format, args...))
+}
+
+func (l logger) warningf(format string, args ...interface{}) {
+	l.log(warningPrefix, fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
# ☢️💀⚠️ Security Concerns ⚠️💀☢️
This GitHub Action has access to a GitHub token with Read and (more importantly) Write privileges to this repo. The use of this token within the master branch (current usage) can be controlled. However, usage in the PR branch (added in this PR) can be modified and the token could be leaked. A solution for this issue needs to be developed if the behavior introduced in this PR is desired.

# Description
Aside from executing the live action from master, this PR includes a second job that executes the action from the PR branch.

# Motivation
Currently, changes introduced by PR can only be tested after being merged into master. Adding this job allows to execute the action before merging so that its behavior can be reviewed before merging.

# PoC
This PR has been merged in my ownh fork to showcase how it works. A [dummy PR](https://github.com/Adirio/kubebuilder-release-tools/pull/15) has been created to show both jobs.
P.S.: the action themselves are still broken (see #17, and #19) and will always success, so the outcome of the jobs is not relevant.
P.S.2: the PR content is just a trivial `README.md` file update, it is not relevant either.