### PR TITLE
🌱 Improve debugging output from the action execution

### DIFF
--- a/.github/actions/verifier/action.yml
+++ b/.github/actions/verifier/action.yml
@@ -6,4 +6,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: '../Dockerfile'
+  image: '../../../Dockerfile'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,17 @@
+name: PR Verifier
+
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
   verify:
+    name: Verify PR contents
     runs-on: ubuntu-latest
-    name: verify PR contents
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Verifier action
-      id: verifier
-      uses: ./action-nightly
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verifier action
+        uses: ./.github/actions/verifier
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The code that actually runs lives in [verify/cmd](/verify/cmd), while
 from GitHub actions & uploading the result via the GitHub checks API.
 
 This repo itself uses a "live" version of the action that always rebuilds
-from the local code, which lives in [action-nightly](/action-nightly).
+from the local code (master branch), which lives in 
+[.github/actions/verifier](/.github/actions/verifier).
 
 ### Updating the action
 

--- a/verify/pkg/log/interface.go
+++ b/verify/pkg/log/interface.go
@@ -14,22 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package verify
+package log
 
-import (
-	"fmt"
-)
-
-type logger struct{}
-
-func (logger) errorf(format string, args ...interface{}) {
-	fmt.Printf("::error::"+format+"\n", args...)
-}
-
-func (logger) debugf(format string, args ...interface{}) {
-	fmt.Printf("::debug::"+format+"\n", args...)
-}
-
-func (logger) warningf(format string, args ...interface{}) {
-	fmt.Printf("::warning::"+format+"\n", args...)
+type Logger interface {
+	Debug(content string)
+	Debugf(format string, args ...interface{})
+	Info(content string)
+	Infof(format string, args ...interface{})
+	Warning(content string)
+	Warningf(format string, args ...interface{})
+	Error(content string)
+	Errorf(format string, args ...interface{})
+	Fatal(exitCode int, content string)
+	Fatalf(exitCode int, format string, args ...interface{})
 }

--- a/verify/pkg/log/level.go
+++ b/verify/pkg/log/level.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+type LoggingLevel uint8
+
+const (
+	Debug = iota
+	Info
+	Warning
+	Error
+)
+
+func (level LoggingLevel) String() string {
+	switch level {
+	case Debug:
+		return "debug"
+	case Info:
+		return "info"
+	case Warning:
+		return "warning"
+	case Error:
+		return "error"
+	default:
+		return "unknown logging level"
+	}
+}

--- a/verify/pkg/log/logger.go
+++ b/verify/pkg/log/logger.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Prefixes used in GitHub actions
+const (
+	ghPrefixDebug   = "::debug::"
+	ghPrefixWarning = "::warning::"
+	ghPrefixError   = "::error::"
+)
+
+// Verify that logger implements Logger
+var _ Logger = logger{}
+
+// logger provides logging functions for GitHub actions
+type logger struct{
+	// Prefixes for the different logging methods
+	prefixDebug   string
+	prefixInfo    string
+	prefixWarning string
+	prefixError   string
+}
+
+// New returns a basic logger for GitHub actions
+func New() Logger {
+	return &logger{
+		prefixDebug:   ghPrefixDebug,
+		prefixInfo:    "",
+		prefixWarning: ghPrefixWarning,
+		prefixError:   ghPrefixError,
+	}
+}
+
+// NewFor returns a named logger for GitHub actions
+func NewFor(name string) Logger {
+	return &logger{
+		prefixDebug:   fmt.Sprintf("%s[%s]", ghPrefixDebug, name),
+		prefixInfo:    fmt.Sprintf("[%s]", name),
+		prefixWarning: fmt.Sprintf("%s[%s]", ghPrefixWarning, name),
+		prefixError:   fmt.Sprintf("%s[%s]", ghPrefixError, name),
+	}
+}
+
+func (l logger) prefixFor(level LoggingLevel) string {
+	switch level {
+	case Debug:
+		return l.prefixDebug
+	case Info:
+		return l.prefixInfo
+	case Warning:
+		return l.prefixWarning
+	case Error:
+		return l.prefixError
+	default:
+		panic("invalid logging level")
+	}
+}
+
+func (l logger) log(content string, level LoggingLevel) {
+	prefix := l.prefixFor(level)
+	for _, s := range strings.Split(content, "\n") {
+		fmt.Println(prefix + s)
+	}
+}
+
+func (l logger) Debug(content string) {
+	l.log(content, Debug)
+}
+
+func (l logger) Debugf(format string, args ...interface{}) {
+	l.Debug(fmt.Sprintf(format, args...))
+}
+
+func (l logger) Info(content string) {
+	l.log(content, Info)
+}
+
+func (l logger) Infof(format string, args ...interface{}) {
+	l.Info(fmt.Sprintf(format, args...))
+}
+
+func (l logger) Warning(content string) {
+	l.log(content, Warning)
+}
+
+func (l logger) Warningf(format string, args ...interface{}) {
+	l.Warning(fmt.Sprintf(format, args...))
+}
+
+func (l logger) Error(content string) {
+	l.log(content, Error)
+}
+
+func (l logger) Errorf(format string, args ...interface{}) {
+	l.Error(fmt.Sprintf(format, args...))
+}
+
+func (l logger) Fatal(exitCode int, content string) {
+	l.log(content, Error)
+	os.Exit(exitCode)
+}
+
+func (l logger) Fatalf(exitCode int, format string, args ...interface{}) {
+	l.Fatal(exitCode, fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
# Description
Improve debugging output to include logging level prefixes for all lines, as if previous logging messages had `/n` and were output with the debug level, the lines after the first one weren't being properly silenced by GitHub.

# Motivation
This improvement was previously implemented as part of #21 and was blocking #20. #21 is considered unsafe and is not going to be merged unless the secutiry caveats can be solved. Thus, this has been extracted as an independent PR to enable #20 bug fix without introducing security issues.

CLoses: #15