### PR TITLE
🌱Move directxman12 to emeritus-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,6 @@ aliases:
   kubebuilder-admins:
     - droot
     - mengqiy
-    - directxman12
     - adirio
 
   # non-admin folks who can approve any PRs in the repo
@@ -24,3 +23,4 @@ aliases:
   # but are no longer directly involved
   kubebuilder-emeritus-approvers:
     - pwittrock
+    - directxman12


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ

AFAIK, Solly does no longer work on K8s, but still get pull requests assigned for review. That is unfortunate. This PR moves Solly to the `kubebuilder-emeritus-approvers` group, and should fix that.