### PR TITLE
✨ Add :rocket: as a valid prefix for release PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ specifying the kind of change:
 - Non-breaking feature: :sparkles: (`:sparkles:`)
 - Patch fix: :bug: (`:bug:`)
 - Docs: :book: (`:book:`)
+- Release: :rocket: (`:rocket:`)
 - Infra/Tests/Other: :seedling: (`:seedling:`)
 
 See [the document](/VERSIONING.md) for more details.

--- a/notes/common/common_test.go
+++ b/notes/common/common_test.go
@@ -50,6 +50,8 @@ var _ = Describe("PR title parsing", func() {
 		Entry("should match infra from :seedling:", ":seedling: Update Go mod version to 1.15", InfraPR, "Update Go mod version to 1.15"),
 		Entry("should match infra from 🏃(deprecated)", "🏃 hack/setup-envtest.sh: follow-up from #1092", InfraPR, "hack/setup-envtest.sh: follow-up from #1092"),
 		Entry("should match infra from :running: (deprecated)", ":running: Proposal to extract cluster-specifics out of the Manager", InfraPR, "Proposal to extract cluster-specifics out of the Manager"),
+		Entry("should match release from :rocket:", ":rocket: release v0.0.1", ReleasePR, "release v0.0.1"),
+		Entry("should match release from 🚀", "🚀 release v0.0.1", ReleasePR, "release v0.0.1"),
 		Entry("should put anything else as uncategorized", "blah blah", UncategorizedPR, "blah blah"),
 	)
 

--- a/notes/common/prefix.go
+++ b/notes/common/prefix.go
@@ -22,6 +22,7 @@ import (
 )
 
 type PRType int
+
 func (t PRType) Emoji() string {
 	switch t {
 	case UncategorizedPR:
@@ -55,7 +56,7 @@ func (t PRType) String() string {
 	case InfraPR:
 		return "infra"
 	default:
-		panic(fmt.Sprintf("unrecognized PR type %v", t))
+		panic(fmt.Sprintf("unrecognized PR type %d", int(t)))
 	}
 }
 
@@ -66,6 +67,7 @@ const (
 	BugfixPR
 	DocsPR
 	InfraPR
+	ReleasePR
 )
 
 // NB(directxman12): These are constants because some folks' dev environments like
@@ -80,6 +82,7 @@ const (
 	emojiInfra       = string('🌱')
 	emojiBreaking    = string('⚠')
 	emojiInfraLegacy = string('🏃')
+	emojiRelease     = string('🚀')
 )
 
 func PRTypeFromTitle(title string) (PRType, string) {
@@ -111,6 +114,10 @@ func PRTypeFromTitle(title string) (PRType, string) {
 		title = strings.TrimPrefix(title, ":warning:")
 		title = strings.TrimPrefix(title, emojiBreaking)
 		prType = BreakingPR
+	case strings.HasPrefix(title, ":rocket:"), strings.HasPrefix(title, emojiRelease):
+		title = strings.TrimPrefix(title, ":rocket:")
+		title = strings.TrimPrefix(title, emojiRelease)
+		prType = ReleasePR
 	case strings.HasPrefix(title, ":running:"), strings.HasPrefix(title, emojiInfraLegacy):
 		// This has been deprecated in favor of :seedling:
 		title = strings.TrimPrefix(title, ":running:")

--- a/verify/type.go
+++ b/verify/type.go
@@ -48,10 +48,11 @@ You need to have one of these as the prefix of your PR title:
 - Non-breaking feature: ✨ (%#q)
 - Patch fix: 🐛 (%#q)
 - Docs: 📖 (%#q)
+- Release: 🚀 (%#q)
 - Infra/Tests/Other: 🌱 (%#q)
 
 More details can be found at [sigs.k8s.io/kubebuilder-release-tools/VERSIONING.md](https://sigs.k8s.io/kubebuilder-release-tools/VERSIONING.md).`,
-		e.title, ":warning:", ":sparkles:", ":bug:", ":book:", ":seedling:")
+		e.title, ":warning:", ":sparkles:", ":bug:", ":book:", ":rocket:", ":seedling:")
 }
 
 // verifyPRType checks that the PR title contains a prefix that defines its type


### PR DESCRIPTION
Fixes #54 by adding :rocket: as a valid emoji prefix

Along the way I adjusted:

```
panic(fmt.Sprintf("unrecognized PR type %v", t))
```

to

```
panic("unrecognized PR type")
```

because I was getting this (rightful) compiler error when running tests:

> fmt.Sprintf format %v with arg t causes recursive (sigs.k8s.io/kubebuilder-release-tools/notes/common.PRType).String method call
