### PR TITLE
:book: Inform users about the deprecation of the PR title validation GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ $ go run sigs.k8s.io/kubebuilder-release-tools/notes
 $ go run sigs.k8s.io/kubebuilder-release-tools/notes -r beta
 ```
 
-## PR Verification GitHub Action
+## PR Verification GitHub Action (Deprecated)
+
+**IMPORTANT**: Images provided under `gcr.io/kubebuilder/` will be unavailable starting **March 18, 2025**. Therefore, this GitHub Action as described below will no longer work once the images are unavailable.
+
+> The functionality of this deprecated GitHub Action can be replicated using the current approach in the Kubebuilder project. Here’s how:
+> - Create a GitHub Action to trigger the validation, as demonstrated in the [Kubebuilder repository](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.github/workflows/verify.yml).
+> - Ensure that the GitHub Action calls the necessary shell script for checks. You can find an example here: [pr-title-checker.sh](https://github.com/kubernetes-sigs/kubebuilder/blob/master/test/pr-title-checker.sh).
+
 
 This repository acts as a GitHub action for verifying PR titles match the
 [release notes generation requirements](/VERSIONING.md), as well as some


### PR DESCRIPTION
This commit informs users that the GitHub Action used for PR title validation is deprecated due to the upcoming unavailability of the images hosted under `gcr.io/kubebuilder/`, effective March 18, 2025.

Users are guided to replicate the functionality by creating a custom GitHub Action, following the approach used in the Kubebuilder project:
- A GitHub Action to trigger the validation: https://github.com/kubernetes-sigs/kubebuilder/blob/master/.github/workflows/verify.yml
- A shell script for checks: https://github.com/kubernetes-sigs/kubebuilder/blob/master/test/pr-title-checker.sh