### PR TITLE
📖 Update README.md, remove link to pr-title-checker.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ $ go run sigs.k8s.io/kubebuilder-release-tools/notes -r beta
 
 > The functionality of this deprecated GitHub Action can be replicated using the current approach in the Kubebuilder project. Here’s how:
 > - Create a GitHub Action to trigger the validation, as demonstrated in the [Kubebuilder repository](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.github/workflows/verify.yml).
-> - Ensure that the GitHub Action calls the necessary shell script for checks. You can find an example here: [pr-title-checker.sh](https://github.com/kubernetes-sigs/kubebuilder/blob/master/test/pr-title-checker.sh).
 
 
 This repository acts as a GitHub action for verifying PR titles match the


### PR DESCRIPTION
`pr-title-checker.sh` was removed in kubebuilder.

The Github actions is now self-contained.